### PR TITLE
Implemented creating shares

### DIFF
--- a/app/src/main/java/me/ocv/partyup/SettingsActivity.java
+++ b/app/src/main/java/me/ocv/partyup/SettingsActivity.java
@@ -7,6 +7,10 @@ import android.view.MenuItem;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import android.widget.Toast;
+
+import androidx.preference.EditTextPreference;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 public class SettingsActivity extends AppCompatActivity {
@@ -37,6 +41,62 @@ public class SettingsActivity extends AppCompatActivity {
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+            EditTextPreference linkExp = findPreference("link_expiration");
+            if (linkExp != null) {
+                // Use SummaryProvider for dynamic summary
+                linkExp.setSummaryProvider(preference -> {
+                    String value = ((EditTextPreference) preference).getText();
+                    return getExpSummaryText(value);
+                });
+
+                // Validate on change
+                linkExp.setOnPreferenceChangeListener((preference, newValue) -> {
+                    String value = (String) newValue;
+                    String error = validateExpiration(value);
+                    if (error != null) {
+                        Toast.makeText(getContext(), error, Toast.LENGTH_SHORT).show();
+                        return false;
+                    }
+                    return true;
+                });
+            }
+        }
+
+        private String validateExpiration(String value) {
+            if (value == null || value.trim().isEmpty())
+                return null; // Empty is valid (never expires)
+
+            value = value.trim().toLowerCase();
+            if (value.matches("^\\d+[mhd]?$"))
+                return null; // Valid format
+
+            return "Invalid format. Use: 30m, 2h, 7d, or empty for never";
+        }
+
+        private String getExpSummaryText(String value) {
+            if (value == null || value.trim().isEmpty())
+                return "Never expires (e.g. 30m, 2h, 7d)";
+
+            value = value.trim().toLowerCase();
+            if (!value.matches("^\\d+[mhd]?$"))
+                return "Invalid format";
+
+            char unit = value.charAt(value.length() - 1);
+            int num;
+            if (Character.isDigit(unit)) {
+                num = Integer.parseInt(value);
+                unit = 'm';
+            } else {
+                num = Integer.parseInt(value.substring(0, value.length() - 1));
+            }
+
+            switch (unit) {
+                case 'm': return num + " minute" + (num != 1 ? "s" : "");
+                case 'h': return num + " hour" + (num != 1 ? "s" : "");
+                case 'd': return num + " day" + (num != 1 ? "s" : "");
+                default: return "Never expires";
+            }
         }
     }
 

--- a/app/src/main/java/me/ocv/partyup/SettingsActivity.java
+++ b/app/src/main/java/me/ocv/partyup/SettingsActivity.java
@@ -76,7 +76,7 @@ public class SettingsActivity extends AppCompatActivity {
 
         private String getExpSummaryText(String value) {
             if (value == null || value.trim().isEmpty())
-                return "Never expires (e.g. 30m, 2h, 7d)";
+                return "Never expires";
 
             value = value.trim().toLowerCase();
             if (!value.matches("^\\d+[mhd]?$"))

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -217,18 +217,59 @@ public class XferActivity extends AppCompatActivity {
         return "bin";
     }
 
+    int[] parseExpiration(String value) {
+        // Returns [number, unit] where unit: 0=minutes, 1=hours, 2=days, -1=invalid/empty
+        if (value == null || value.trim().isEmpty())
+            return new int[]{0, -1};
+
+        value = value.trim().toLowerCase();
+        if (!value.matches("^\\d+[mhd]?$"))
+            return new int[]{0, -1};
+
+        char unit = value.charAt(value.length() - 1);
+        int num;
+        int unitType;
+
+        if (Character.isDigit(unit)) {
+            num = Integer.parseInt(value);
+            unitType = 0; // minutes
+        } else {
+            num = Integer.parseInt(value.substring(0, value.length() - 1));
+            switch (unit) {
+                case 'h': unitType = 1; break;
+                case 'd': unitType = 2; break;
+                default: unitType = 0; break;
+            }
+        }
+        return new int[]{num, unitType};
+    }
+
+    String getExpirationMinutes() {
+        String value = prefs.getString("link_expiration", "");
+        int[] parsed = parseExpiration(value);
+        if (parsed[1] < 0)
+            return "";
+
+        int minutes = parsed[0];
+        if (parsed[1] == 1) minutes *= 60;       // hours
+        else if (parsed[1] == 2) minutes *= 1440; // days
+
+        return String.valueOf(minutes);
+    }
+
     String getExpirationLabel() {
-        String exp = prefs.getString("share_expiration", "");
-        if (exp == null || exp.isEmpty())
+        String value = prefs.getString("link_expiration", "");
+        int[] parsed = parseExpiration(value);
+        if (parsed[1] < 0)
             return "never expires";
 
-        int minutes = Integer.parseInt(exp);
-        if (minutes < 60)
-            return minutes + " min";
-        if (minutes < 1440)
-            return (minutes / 60) + " hour" + (minutes >= 120 ? "s" : "");
-        int days = minutes / 1440;
-        return days + " day" + (days > 1 ? "s" : "");
+        int num = parsed[0];
+        switch (parsed[1]) {
+            case 0: return num + " minute" + (num != 1 ? "s" : "");
+            case 1: return num + " hour" + (num != 1 ? "s" : "");
+            case 2: return num + " day" + (num != 1 ? "s" : "");
+            default: return "never expires";
+        }
     }
 
     private void handleSendText() {
@@ -510,8 +551,8 @@ public class XferActivity extends AppCompatActivity {
                 shareApiUrl += ":" + url.getPort();
             shareApiUrl += "/?share";
 
-            // Get expiration preference (seconds as string)
-            String expiration = prefs.getString("share_expiration", "");
+            // Get expiration in minutes
+            String expiration = getExpirationMinutes();
 
             // Build JSON body
             String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"\",\"exp\":\"%s\",\"perms\":[\"read\"]}",

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -45,6 +45,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Base64;
 
@@ -458,12 +459,75 @@ public class XferActivity extends AppCompatActivity {
             tshow_msg("ERROR:\nFile got corrupted during the upload;\n\n" + lines[2] + " expected\n" + sha + " from server");
             return false;
         }
+
         if (lines.length > 3 && !lines[3].isEmpty())
             f.share_url = lines[3];
         else
             f.share_url = f.full_url.split("\\?")[0];
 
+        if (prefs.getBoolean("use_share_url", false))
+            createShareUrl(f);
+
         return true;
+    }
+
+    void createShareUrl(F f) {
+        try {
+            // Generate random key
+            String chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+            SecureRandom random = new SecureRandom();
+            StringBuilder key = new StringBuilder();
+            for (int i = 0; i < 12; i++)
+                key.append(chars.charAt(random.nextInt(chars.length())));
+
+            // Extract file path from URL
+            URL url = new URL(f.full_url);
+            String filePath = url.getPath();
+
+            // Build share API URL (base URL without file path)
+            String shareApiUrl = url.getProtocol() + "://" + url.getHost();
+            if (url.getPort() != -1)
+                shareApiUrl += ":" + url.getPort();
+            shareApiUrl += "/?share";
+
+            // Build JSON body
+            String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"\",\"exp\":\"\",\"perms\":[\"read\"]}",
+                    key.toString(), filePath);
+
+            URL apiUrl = new URL(shareApiUrl);
+            HttpURLConnection conn = (HttpURLConnection) apiUrl.openConnection();
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "text/plain");
+            if (password != null)
+                conn.setRequestProperty("PW", password);
+
+            byte[] body = jsonBody.getBytes(StandardCharsets.UTF_8);
+            conn.setFixedLengthStreamingMode(body.length);
+            conn.connect();
+
+            OutputStream os = conn.getOutputStream();
+            os.write(body);
+            os.flush();
+
+            int rc = conn.getResponseCode();
+            if (rc >= 300) {
+                Log.w("me.ocv.partyup", "Share creation failed: " + rc);
+                conn.disconnect();
+                return;
+            }
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String response = br.readLine();
+            conn.disconnect();
+
+            // Parse response: "created share: https://..."
+            if (response != null && response.startsWith("created share: "))
+                f.share_url = response.substring(15);
+
+        } catch (Exception ex) {
+            Log.w("me.ocv.partyup", "Share creation error: " + ex.toString());
+        }
     }
 
     void onsuccess() {

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.preference.PreferenceManager;
@@ -274,11 +275,25 @@ public class XferActivity extends AppCompatActivity {
 
     private void handleSendText() {
         String msg = "Post the following link?\n\n" + the_msg;
-        if (prefs.getBoolean("use_share_url", false))
-            msg += "\n\n📤 Share link: " + getExpirationLabel();
         show_msg(msg);
+        showShareSettings();
         if (prefs.getBoolean("autosend", false))
             do_up();
+    }
+
+    private void showShareSettings() {
+        if (prefs.getBoolean("use_share_url", false)) {
+            findViewById(R.id.share_settings).setVisibility(View.VISIBLE);
+
+            EditText expField = findViewById(R.id.share_expiration);
+            EditText pwField = findViewById(R.id.share_password);
+
+            String defaultExp = prefs.getString("link_expiration", "");
+            String defaultPw = prefs.getString("share_password", "");
+
+            expField.setText(defaultExp != null ? defaultExp : "");
+            pwField.setText(defaultPw != null ? defaultPw : "");
+        }
     }
 
     @SuppressLint("DefaultLocale")
@@ -360,10 +375,8 @@ public class XferActivity extends AppCompatActivity {
 
             msg += format("\n(total %,d bytes)", bytes_total);
         }
-        if (prefs.getBoolean("use_share_url", false)) {
-            msg += "\n\n📤 Share link: " + getExpirationLabel();
-        }
         show_msg(msg);
+        showShareSettings();
         if (prefs.getBoolean("autosend", false))
             do_up();
     }
@@ -551,12 +564,21 @@ public class XferActivity extends AppCompatActivity {
                 shareApiUrl += ":" + url.getPort();
             shareApiUrl += "/?share";
 
-            // Get expiration in minutes
-            String expiration = getExpirationMinutes();
+            // Get expiration from UI field
+            EditText expField = findViewById(R.id.share_expiration);
+            String expValue = expField.getText().toString();
+            int[] parsed = parseExpiration(expValue);
+            String expiration = "";
+            if (parsed[1] >= 0) {
+                int minutes = parsed[0];
+                if (parsed[1] == 1) minutes *= 60;
+                else if (parsed[1] == 2) minutes *= 1440;
+                expiration = String.valueOf(minutes);
+            }
 
-            // Get share password
-            String sharePw = prefs.getString("share_password", "");
-            if (sharePw == null) sharePw = "";
+            // Get password from UI field
+            EditText pwField = findViewById(R.id.share_password);
+            String sharePw = pwField.getText().toString();
 
             // Build JSON body
             String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"%s\",\"exp\":\"%s\",\"perms\":[\"read\"]}",
@@ -623,6 +645,7 @@ public class XferActivity extends AppCompatActivity {
         }
 
         findViewById(R.id.progbar).setVisibility(View.GONE);
+        findViewById(R.id.share_settings).setVisibility(View.GONE);
         findViewById(R.id.successbuttons).setVisibility(View.VISIBLE);
 
         Button btn = (Button) findViewById(R.id.btnExit);

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -274,8 +274,7 @@ public class XferActivity extends AppCompatActivity {
     }
 
     private void handleSendText() {
-        String msg = "Post the following link?\n\n" + the_msg;
-        show_msg(msg);
+        show_msg("Post the following link?\n\n" + the_msg);
         showShareSettings();
         if (prefs.getBoolean("autosend", false))
             do_up();
@@ -564,7 +563,7 @@ public class XferActivity extends AppCompatActivity {
                 shareApiUrl += ":" + url.getPort();
             shareApiUrl += "/?share";
 
-            // Get expiration from UI field
+            // Get expiration
             EditText expField = findViewById(R.id.share_expiration);
             String expValue = expField.getText().toString();
             int[] parsed = parseExpiration(expValue);
@@ -576,7 +575,7 @@ public class XferActivity extends AppCompatActivity {
                 expiration = String.valueOf(minutes);
             }
 
-            // Get password from UI field
+            // Get password
             EditText pwField = findViewById(R.id.share_password);
             String sharePw = pwField.getText().toString();
 

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -554,9 +554,13 @@ public class XferActivity extends AppCompatActivity {
             // Get expiration in minutes
             String expiration = getExpirationMinutes();
 
+            // Get share password
+            String sharePw = prefs.getString("share_password", "");
+            if (sharePw == null) sharePw = "";
+
             // Build JSON body
-            String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"\",\"exp\":\"%s\",\"perms\":[\"read\"]}",
-                    key.toString(), filePath, expiration);
+            String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"%s\",\"exp\":\"%s\",\"perms\":[\"read\"]}",
+                    key.toString(), filePath, sharePw, expiration);
 
             URL apiUrl = new URL(shareApiUrl);
             HttpURLConnection conn = (HttpURLConnection) apiUrl.openConnection();

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -217,8 +217,25 @@ public class XferActivity extends AppCompatActivity {
         return "bin";
     }
 
+    String getExpirationLabel() {
+        String exp = prefs.getString("share_expiration", "");
+        if (exp == null || exp.isEmpty())
+            return "never expires";
+
+        int minutes = Integer.parseInt(exp);
+        if (minutes < 60)
+            return minutes + " min";
+        if (minutes < 1440)
+            return (minutes / 60) + " hour" + (minutes >= 120 ? "s" : "");
+        int days = minutes / 1440;
+        return days + " day" + (days > 1 ? "s" : "");
+    }
+
     private void handleSendText() {
-        show_msg("Post the following link?\n\n" + the_msg);
+        String msg = "Post the following link?\n\n" + the_msg;
+        if (prefs.getBoolean("use_share_url", false))
+            msg += "\n\n📤 Share link: " + getExpirationLabel();
+        show_msg(msg);
         if (prefs.getBoolean("autosend", false))
             do_up();
     }
@@ -301,6 +318,9 @@ public class XferActivity extends AppCompatActivity {
                 msg += "[...]\n";
 
             msg += format("\n(total %,d bytes)", bytes_total);
+        }
+        if (prefs.getBoolean("use_share_url", false)) {
+            msg += "\n\n📤 Share link: " + getExpirationLabel();
         }
         show_msg(msg);
         if (prefs.getBoolean("autosend", false))
@@ -490,9 +510,12 @@ public class XferActivity extends AppCompatActivity {
                 shareApiUrl += ":" + url.getPort();
             shareApiUrl += "/?share";
 
+            // Get expiration preference (seconds as string)
+            String expiration = prefs.getString("share_expiration", "");
+
             // Build JSON body
-            String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"\",\"exp\":\"\",\"perms\":[\"read\"]}",
-                    key.toString(), filePath);
+            String jsonBody = format("{\"k\":\"%s\",\"vp\":[\"%s\"],\"pw\":\"\",\"exp\":\"%s\",\"perms\":[\"read\"]}",
+                    key.toString(), filePath, expiration);
 
             URL apiUrl = new URL(shareApiUrl);
             HttpURLConnection conn = (HttpURLConnection) apiUrl.openConnection();

--- a/app/src/main/java/me/ocv/partyup/XferActivity.java
+++ b/app/src/main/java/me/ocv/partyup/XferActivity.java
@@ -500,9 +500,9 @@ public class XferActivity extends AppCompatActivity {
             for (int i = 0; i < 12; i++)
                 key.append(chars.charAt(random.nextInt(chars.length())));
 
-            // Extract file path from URL
+            // Extract file path from URL and decode it
             URL url = new URL(f.full_url);
-            String filePath = url.getPath();
+            String filePath = java.net.URLDecoder.decode(url.getPath(), "UTF-8");
 
             // Build share API URL (base URL without file path)
             String shareApiUrl = url.getProtocol() + "://" + url.getHost();

--- a/app/src/main/res/layout/activity_xfer.xml
+++ b/app/src/main/res/layout/activity_xfer.xml
@@ -63,6 +63,62 @@
                 android:layout_weight="1" />
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/share_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="24dp"
+            android:paddingTop="16dp"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Expires:"
+                    android:textSize="14sp" />
+
+                <EditText
+                    android:id="@+id/share_expiration"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:hint="e.g. 30m, 2h, 7d"
+                    android:inputType="text"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Password:"
+                    android:textSize="14sp" />
+
+                <EditText
+                    android:id="@+id/share_password"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:hint="optional"
+                    android:inputType="text"
+                    android:textSize="14sp" />
+            </LinearLayout>
+        </LinearLayout>
+
         <Space
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,28 +1,21 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/animegirl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:scaleType="fitEnd"
+        android:adjustViewBounds="true"
+        android:alpha="0.3"
+        app:srcCompat="@drawable/ame" />
 
     <FrameLayout
         android:id="@+id/settings"
         android:layout_width="match_parent"
-        android:layout_height="460dp">
+        android:layout_height="match_parent" />
 
-    </FrameLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal">
-
-        <ImageView
-            android:id="@+id/animegirl"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:tileMode="clamp"
-            app:srcCompat="@drawable/ame" />
-
-    </LinearLayout>
-
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,20 @@
         <item>Share file link</item>
         <item>Exit app</item>
     </string-array>
+    <string-array name="share_exp_values">
+        <item></item>
+        <item>60</item>
+        <item>360</item>
+        <item>1440</item>
+        <item>10080</item>
+        <item>43200</item>
+    </string-array>
+    <string-array name="share_exp_labels">
+        <item>Never expires</item>
+        <item>1 hour</item>
+        <item>6 hours</item>
+        <item>1 day</item>
+        <item>1 week</item>
+        <item>30 days</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,20 +12,4 @@
         <item>Share file link</item>
         <item>Exit app</item>
     </string-array>
-    <string-array name="share_exp_values">
-        <item></item>
-        <item>60</item>
-        <item>360</item>
-        <item>1440</item>
-        <item>10080</item>
-        <item>43200</item>
-    </string-array>
-    <string-array name="share_exp_labels">
-        <item>Never expires</item>
-        <item>1 hour</item>
-        <item>6 hours</item>
-        <item>1 day</item>
-        <item>1 week</item>
-        <item>30 days</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -26,6 +26,11 @@
             android:key="autosend"
             android:title="Just go"
             app:summary="Skip confirmation screen" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="use_share_url"
+            android:title="Use share link"
+            app:summary="Copy share link instead of direct file URL" />
         <ListPreference
             android:defaultValue="close"
             android:entries="@array/vonsuccess"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -41,14 +41,11 @@
             android:key="use_share_url"
             android:title="Use share link"
             app:summary="Create a share link instead of using direct file URL" />
-        <ListPreference
+        <EditTextPreference
             android:defaultValue=""
-            android:entries="@array/share_exp_labels"
-            android:entryValues="@array/share_exp_values"
-            android:key="share_expiration"
+            android:key="link_expiration"
             android:title="Link expiration"
-            android:dependency="use_share_url"
-            app:useSimpleSummaryProvider="true" />
+            android:dependency="use_share_url" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -26,17 +26,28 @@
             android:key="autosend"
             android:title="Just go"
             app:summary="Skip confirmation screen" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="use_share_url"
-            android:title="Use share link"
-            app:summary="Copy share link instead of direct file URL" />
         <ListPreference
             android:defaultValue="close"
             android:entries="@array/vonsuccess"
             android:entryValues="@array/konsuccess"
             android:key="on_up_ok"
             android:title="On upload success..."
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Share links">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="use_share_url"
+            android:title="Use share link"
+            app:summary="Create a share link instead of using direct file URL" />
+        <ListPreference
+            android:defaultValue=""
+            android:entries="@array/share_exp_labels"
+            android:entryValues="@array/share_exp_values"
+            android:key="share_expiration"
+            android:title="Link expiration"
+            android:dependency="use_share_url"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -40,12 +40,18 @@
             android:defaultValue="false"
             android:key="use_share_url"
             android:title="Use share link"
-            app:summary="Create a share link instead of using direct file URL" />
+            app:summary="Create a (temporary) share link" />
         <EditTextPreference
             android:defaultValue=""
             android:key="link_expiration"
-            android:title="Link expiration"
+            android:title="Default expiration (e.g., 10m, 2h, 1d)"
             android:dependency="use_share_url" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="share_password"
+            android:title="Default password"
+            android:dependency="use_share_url"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
From https://github.com/9001/party-up/issues/11#issuecomment-3608319611

> All of that said, I would still be very happy to accept contributions!

Hope this helps! I am new to Android development however, so feel free to leave (many) remarks :)

Partially implements #8

## Settings menu
Expanded the settings menu with a "use share link" toggle with further allows for setting an expiration duration and password:
<img width="329" height="702" alt="image" src="https://github.com/user-attachments/assets/590fa74a-e84f-489b-95b7-6a62a0bccf98" />

Moved the anime girl to the background so that all settings are available on the screen

## Confirmation screen
<img width="332" height="706" alt="image" src="https://github.com/user-attachments/assets/a05acc0b-7ea3-4cf9-9d5c-5c452e3104e5" />

Added editable expiration and password values for the confirmation screen, this doesnt update the setting, but overrides it for that share attempt

## Notes
When the Share API request fails, it still continues with the original URL. I wasn't sure which option was preferred, but figured manually sharing afterwards is better than not being able to share it at all

I implemented a similar retrieval of getting the URL from the share API response as done in the frontend (`surl = surl.slice(15).trim();`). however, if this ever changes, it would break this feature