### PR TITLE
Change password setting to no longer show password in plaintext

### DIFF
--- a/app/src/main/java/me/ocv/partyup/SettingsActivity.java
+++ b/app/src/main/java/me/ocv/partyup/SettingsActivity.java
@@ -3,6 +3,7 @@ package me.ocv.partyup;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.text.InputType;
 import android.view.MenuItem;
 
 import androidx.appcompat.app.ActionBar;
@@ -10,7 +11,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 
 import androidx.preference.EditTextPreference;
-import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 public class SettingsActivity extends AppCompatActivity {
@@ -41,6 +41,25 @@ public class SettingsActivity extends AppCompatActivity {
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+            EditTextPreference passwd = findPreference("server_password");
+            if (passwd != null) {
+                passwd.setSummaryProvider(preference -> {
+                    if (passwd.getText() == null || passwd.getText().isEmpty()) {
+                        return "Password is not set";
+                    } else {
+                        return null;
+                    }
+                });
+                passwd.setOnBindEditTextListener(editText ->
+                    editText.setInputType(
+                        InputType.TYPE_CLASS_TEXT |
+                        InputType.TYPE_TEXT_VARIATION_PASSWORD
+                    )
+                );
+
+                passwd.setDialogMessage("If server has enabled login using usernames, input \"<username>:<password>\"");
+            }
 
             EditTextPreference linkExp = findPreference("link_expiration");
             if (linkExp != null) {

--- a/app/src/main/java/me/ocv/partyup/SettingsActivity.java
+++ b/app/src/main/java/me/ocv/partyup/SettingsActivity.java
@@ -48,17 +48,24 @@ public class SettingsActivity extends AppCompatActivity {
                     if (passwd.getText() == null || passwd.getText().isEmpty()) {
                         return "Password is not set";
                     } else {
-                        return null;
+                        return "Click to change password";
                     }
                 });
-                passwd.setOnBindEditTextListener(editText ->
+                passwd.setOnBindEditTextListener(editText -> {
                     editText.setInputType(
-                        InputType.TYPE_CLASS_TEXT |
-                        InputType.TYPE_TEXT_VARIATION_PASSWORD
-                    )
-                );
+                            InputType.TYPE_CLASS_TEXT |
+                                    InputType.TYPE_TEXT_VARIATION_PASSWORD
+                    );
+                    editText.setOnLongClickListener(view -> {
+                        editText.setInputType(
+                                InputType.TYPE_CLASS_TEXT
+                        );
+                        editText.setOnLongClickListener(null);
+                        return true;
+                    });
+                });
 
-                passwd.setDialogMessage("If server has enabled login using usernames, input \"<username>:<password>\"");
+                passwd.setDialogMessage("If server has enabled login using usernames, input \"<username>:<password>\" \n\n Long press to reveal the password");
             }
 
             EditTextPreference linkExp = findPreference("link_expiration");


### PR DESCRIPTION
As mentioned in #11 having password displayed in plain text is bad security-wise, so i changed it

I also added description to the password dialog that says what to input if server has enabled login using usernames (  #7 )

![Screenshot_2025-12-25-15-13-55-07_9c2f008743a58726ce94a9e9e9179139](https://github.com/user-attachments/assets/8a1eb81a-4e47-458d-8a7e-364eae0be13f)
![Screenshot_2025-12-25-15-13-01-08_9c2f008743a58726ce94a9e9e9179139](https://github.com/user-attachments/assets/d231e530-a47a-48a3-9b23-c5dca9e91d32)
![Screenshot_2025-12-25-15-13-17-40_9c2f008743a58726ce94a9e9e9179139](https://github.com/user-attachments/assets/bf69fd76-9b69-4432-a199-c257aedc6e19)